### PR TITLE
Honeypot Feature - Implementation Summary

### DIFF
--- a/app/Http/Controllers/FormSubmissionController.php
+++ b/app/Http/Controllers/FormSubmissionController.php
@@ -22,6 +22,12 @@ class FormSubmissionController extends Controller
 
         $data = $request->all();
 
+        // Check honeypot field if configured
+        if ($form->isHoneypotTriggered($data)) {
+            // Return 200 status to avoid giving bots feedback, but don't process the submission
+            return redirect($form->redirect_url ?: "/f/{$form->ulid}/thank-you");
+        }
+
         $submission = $form->submissions()->create([
             'data' => $data,
             'ip_address' => $request->ip(),

--- a/app/Http/Controllers/FormSubmissionController.php
+++ b/app/Http/Controllers/FormSubmissionController.php
@@ -25,7 +25,7 @@ class FormSubmissionController extends Controller
         // Check honeypot field if configured
         if ($form->isHoneypotTriggered($data)) {
             // Return 200 status to avoid giving bots feedback, but don't process the submission
-            return redirect($form->redirect_url ?: "/f/{$form->ulid}/thank-you");
+            return $this->redirectToThankYou($form);
         }
 
         $submission = $form->submissions()->create([
@@ -39,6 +39,11 @@ class FormSubmissionController extends Controller
             ->each(fn ($email) => Notification::route('mail', $email)
                 ->notify(new FormSubmissionReceived($form, $submission)));
 
+        return $this->redirectToThankYou($form);
+    }
+
+    private function redirectToThankYou(Form $form)
+    {
         return redirect($form->redirect_url ?: "/f/{$form->ulid}/thank-you");
     }
 }

--- a/app/Models/Form.php
+++ b/app/Models/Form.php
@@ -88,4 +88,17 @@ class Form extends Model
 
         return false;
     }
+
+    public function isHoneypotTriggered(array $data): bool
+    {
+        // If no honeypot field is configured, allow all submissions
+        if (empty($this->honeypot_field)) {
+            return false;
+        }
+
+        // Check if the honeypot field has any value (after trimming whitespace)
+        $honeypotValue = trim($data[$this->honeypot_field] ?? '');
+        
+        return !empty($honeypotValue);
+    }
 }

--- a/database/factories/FormFactory.php
+++ b/database/factories/FormFactory.php
@@ -22,6 +22,7 @@ class FormFactory extends Factory
             'redirect_url' => null,
             'logo_path' => null,
             'allowed_domains' => null,
+            'honeypot_field' => null,
         ];
     }
 }

--- a/database/migrations/2025_06_10_001703_add_honeypot_field_to_forms_table.php
+++ b/database/migrations/2025_06_10_001703_add_honeypot_field_to_forms_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('forms', function (Blueprint $table) {
+            $table->string('honeypot_field')->nullable()->after('allowed_domains');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('forms', function (Blueprint $table) {
+            $table->dropColumn('honeypot_field');
+        });
+    }
+};

--- a/resources/views/pages/forms/[Form]/settings.blade.php
+++ b/resources/views/pages/forms/[Form]/settings.blade.php
@@ -19,6 +19,7 @@ new class extends Component {
     public string $forward_to = '';
     public string $redirect_url = '';
     public string $allowed_domains = '';
+    public string $honeypot_field = '';
     public array $forward_to_emails = [];
     public $logo;
 
@@ -28,6 +29,7 @@ new class extends Component {
         $this->forward_to = $this->form->forward_to ?? '';
         $this->redirect_url = $this->form->redirect_url ?? '';
         $this->allowed_domains = $this->form->allowed_domains ?? '';
+        $this->honeypot_field = $this->form->honeypot_field ?? '';
     }
 
     public function save()
@@ -39,6 +41,7 @@ new class extends Component {
             'forward_to' => 'nullable|string',
             'redirect_url' => 'nullable|url',
             'allowed_domains' => 'nullable|string',
+            'honeypot_field' => 'nullable|string|max:255',
             'forward_to_emails.*' => 'sometimes|email',
             'logo' => 'nullable|image|max:2048',
         ]);
@@ -48,6 +51,7 @@ new class extends Component {
             'forward_to' => implode("\n", $this->forward_to_emails),
             'redirect_url' => $this->redirect_url,
             'allowed_domains' => $this->allowed_domains,
+            'honeypot_field' => $this->honeypot_field,
         ];
 
         if ($this->logo) {
@@ -168,6 +172,15 @@ new class extends Component {
                     :badge="__('Optional')"
                     :description:trailing="__('Comma-separated list of domains that can submit to this form (e.g., example.com, mysite.org). If left empty, submissions from any domain will be accepted.')"
                     placeholder="example.com, mysite.org"
+                />
+
+                <flux:input
+                    wire:model="honeypot_field"
+                    name="honeypot_field"
+                    :label="__('Honeypot Field Name')"
+                    :badge="__('Optional')"
+                    :description:trailing="__('Name of a hidden field to catch spam bots. If a submission includes this field with a value, it will be rejected. Leave empty to disable spam protection.')"
+                    placeholder="website"
                 />
 
                 <div class="flex max-sm:flex-col-reverse items-center max:sm:flex-col justify-end gap-3 max-sm:*:w-full">

--- a/tests/Feature/Controllers/FormSubmissionTest.php
+++ b/tests/Feature/Controllers/FormSubmissionTest.php
@@ -3,7 +3,6 @@
 use App\Models\Form;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Notification;
-use Illuminate\Support\Str;
 
 uses(RefreshDatabase::class);
 

--- a/tests/Feature/Controllers/FormSubmissionTest.php
+++ b/tests/Feature/Controllers/FormSubmissionTest.php
@@ -266,7 +266,7 @@ it('rejects submissions when honeypot field has a value', function () {
 
     $response = $this->post("/f/{$form->ulid}", $data);
 
-    $response->assertStatus(403);
+    $response->assertRedirect("/f/{$form->ulid}/thank-you");
     $this->assertDatabaseMissing('form_submissions', [
         'form_id' => $form->id,
     ]);
@@ -286,6 +286,25 @@ it('trims honeypot field whitespace when checking', function () {
 
     $response->assertRedirect("/f/{$form->ulid}/thank-you");
     $this->assertDatabaseHas('form_submissions', [
+        'form_id' => $form->id,
+    ]);
+});
+
+it('redirects to custom URL when honeypot is triggered and custom redirect is set', function () {
+    $form = Form::factory()->create([
+        'honeypot_field' => 'website',
+        'redirect_url' => 'https://example.com/custom-thank-you',
+    ]);
+    $data = [
+        'name' => 'Bot Name',
+        'email' => 'bot@example.com',
+        'website' => 'http://spam.com', // Honeypot field has value (bad)
+    ];
+
+    $response = $this->post("/f/{$form->ulid}", $data);
+
+    $response->assertRedirect('https://example.com/custom-thank-you');
+    $this->assertDatabaseMissing('form_submissions', [
         'form_id' => $form->id,
     ]);
 });

--- a/tests/Feature/Pages/FormSettingsTest.php
+++ b/tests/Feature/Pages/FormSettingsTest.php
@@ -360,7 +360,7 @@ it('can clear honeypot field', function () {
 
     assertDatabaseHas('forms', [
         'id' => $form->id,
-        'honeypot_field' => '',
+        'honeypot_field' => null,
     ]);
 });
 


### PR DESCRIPTION
## 🚀 **Usage Example**

**Settings Configuration:**
```
Honeypot Field Name: website
```

**HTML Form:**
```html
<!-- Visible fields -->
<input type="text" name="name" required>
<input type="email" name="email" required>

<!-- Hidden honeypot field -->
<input type="text" name="website" style="display:none" tabindex="-1">
```

**Result:**
- Human users: Can't see honeypot → leave it empty → submission accepted ✅
- Spam bots: Fill all fields → honeypot has value → submission silently rejected ❌