### PR TITLE
Cloudflare Turnstile Integration

### DIFF
--- a/app/Http/Controllers/FormSubmissionController.php
+++ b/app/Http/Controllers/FormSubmissionController.php
@@ -28,6 +28,11 @@ class FormSubmissionController extends Controller
             return $this->redirectToThankYou($form);
         }
 
+        // Check Turnstile if configured
+        if (!$form->isTurnstileValid($request->input('cf-turnstile-response'), $request->ip())) {
+            abort(403, 'Turnstile validation failed');
+        }
+
         $submission = $form->submissions()->create([
             'data' => $data,
             'ip_address' => $request->ip(),

--- a/database/factories/FormFactory.php
+++ b/database/factories/FormFactory.php
@@ -23,6 +23,7 @@ class FormFactory extends Factory
             'logo_path' => null,
             'allowed_domains' => null,
             'honeypot_field' => null,
+            'turnstile_secret_key' => null,
         ];
     }
 }

--- a/database/migrations/2025_06_10_021059_add_turnstile_secret_key_to_forms_table.php
+++ b/database/migrations/2025_06_10_021059_add_turnstile_secret_key_to_forms_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('forms', function (Blueprint $table) {
+            $table->string('turnstile_secret_key')->nullable()->after('honeypot_field');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('forms', function (Blueprint $table) {
+            $table->dropColumn('turnstile_secret_key');
+        });
+    }
+};

--- a/resources/views/pages/forms/[Form]/settings.blade.php
+++ b/resources/views/pages/forms/[Form]/settings.blade.php
@@ -20,6 +20,7 @@ new class extends Component {
     public string $redirect_url = '';
     public string $allowed_domains = '';
     public string $honeypot_field = '';
+    public string $turnstile_secret_key = '';
     public array $forward_to_emails = [];
     public $logo;
 
@@ -30,6 +31,7 @@ new class extends Component {
         $this->redirect_url = $this->form->redirect_url ?? '';
         $this->allowed_domains = $this->form->allowed_domains ?? '';
         $this->honeypot_field = $this->form->honeypot_field ?? '';
+        $this->turnstile_secret_key = $this->form->turnstile_secret_key ?? '';
     }
 
     public function save()
@@ -42,6 +44,7 @@ new class extends Component {
             'redirect_url' => 'nullable|url',
             'allowed_domains' => 'nullable|string',
             'honeypot_field' => 'nullable|string|max:255',
+            'turnstile_secret_key' => 'nullable|string|max:255',
             'forward_to_emails.*' => 'sometimes|email',
             'logo' => 'nullable|image|max:2048',
         ]);
@@ -52,6 +55,7 @@ new class extends Component {
             'redirect_url' => $this->redirect_url,
             'allowed_domains' => $this->allowed_domains,
             'honeypot_field' => $this->honeypot_field ?: null,
+            'turnstile_secret_key' => $this->turnstile_secret_key ?: null,
         ];
 
         if ($this->logo) {
@@ -181,6 +185,16 @@ new class extends Component {
                     :badge="__('Optional')"
                     :description:trailing="__('Name of a hidden field to catch spam bots. If a submission includes this field with a value, it will be rejected. Leave empty to disable spam protection.')"
                     placeholder="website"
+                />
+
+                <flux:input
+                    wire:model="turnstile_secret_key"
+                    name="turnstile_secret_key"
+                    type="password"
+                    :label="__('Cloudflare Turnstile Secret Key')"
+                    :badge="__('Optional')"
+                    :description:trailing="__('Secret key for Cloudflare Turnstile verification. If provided, all form submissions must include a valid Turnstile token. Leave empty to disable Turnstile protection.')"
+                    placeholder="0x4AAAAAAABkMYinukE_NJBz..."
                 />
 
                 <div class="flex max-sm:flex-col-reverse items-center max:sm:flex-col justify-end gap-3 max-sm:*:w-full">


### PR DESCRIPTION
# Cloudflare Turnstile Integration

This feature allows forms to use Cloudflare Turnstile for bot protection. When configured, all form submissions must include a valid Turnstile token.

## How to Configure

1. Go to your form's settings page
2. Add your Cloudflare Turnstile secret key in the "Cloudflare Turnstile Secret Key" field
3. Save the settings

## How it Works

- If no secret key is configured, Turnstile validation is skipped
- If a secret key is configured, all submissions must include a `cf-turnstile-response` field
- The server validates the token with Cloudflare's API
- Invalid or missing tokens result in a 403 error
- API errors are treated as validation failures for security

## Frontend Implementation

When using Turnstile on your forms, include the Cloudflare Turnstile widget and ensure it adds the `cf-turnstile-response` field to your form submission.

Example:
```html
<form action="https://your-app.com/f/your-form-ulid" method="POST">
  <input type="text" name="name" required>
  <input type="email" name="email" required>
  
  <!-- Cloudflare Turnstile widget -->
  <div class="cf-turnstile" data-sitekey="your-site-key"></div>
  
  <button type="submit">Submit</button>
</form>

<script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
```

## Security Notes

- The secret key is stored securely and only accessible via the settings page
- Failed validations return 403 status codes
- No submissions are stored when Turnstile validation fails
- API timeouts and errors fail closed (reject submission) for security
